### PR TITLE
Fix precedence

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,9 +2,9 @@
 {% set pname = "hwloc" %}
 {% set version = "2.9.2" %}
 {% set sha256 = "ffb554d5735e0e0a19d1fd4b2b86e771d3b58b2d97f257eedacae67ade5054b3" %}
-{% set build_num = 6 %}
+{% set build_num = 7 %}
 
-{% if cuda_compiler_version != "None" %}
+{% if cuda_compiler_version == "None" %}
 {% set build_num = build_num + 1000 %}
 {% endif %}
 


### PR DESCRIPTION
This was an oversight where the equal sign was flipped.

Otherwise we get the following error on CI

```
RuntimeError: Solver could not find solution.Mamba failed to solve:
 - pyopencl
 - pocl-cpu
 - curl
 - libhwloc >=2.9.2,<2.9.3.0a0
 - libhwloc >=2.9.2,<3.0a0
 - libclang-cpp15 >=15.0.7,<15.1.0a0
 - ocl-icd >=2.3.1,<3.0a0
 - libstdcxx-ng >=12
 - libllvm15 >=15.0.7,<15.1.0a0
 - libgcc-ng >=12
 - llvm-spirv-15

with channels:

The reported errors are:
- Encountered problems while solving:
-   - nothing provides __cuda needed by libhwloc-2.9.1-cuda102_h47c979d_1006
- 
```